### PR TITLE
Update docs to refer to PostgreSQL and Render

### DIFF
--- a/300.md
+++ b/300.md
@@ -6,14 +6,9 @@ You can use any database of your choosing - most likely PostgreSQL or MongoDB.
 
 ## Setting up your Database
 
-To setup your database you can use either
+To setup your database prefer using PostgreSQL on Render.
 
-- MongoDB
-  - Using MongoDB Atlas
-  - https://www.mongodb.com/cloud/atlas
-- PostgreSQL
-  - Using Heroku
-  - https://dev.to/prisma/how-to-setup-a-free-postgresql-database-on-heroku-1dc1
+Please read the guide at https://syllabus.codeyourfuture.io/guides/deployment-render/creating-a-postgres-db on how to install PostgreSQL on Render
 
 Ask for help on Slack if you need help with this
 


### PR DESCRIPTION
Heroku is no longer free, and the trainees are now taught PostgreSQL. The option to use Mongo is still in the notes if they want to, but the docs will link to the PostgreSQL setup for Render