### PR TITLE
Add explicit requirement for backend to support rating updates

### DIFF
--- a/200.md
+++ b/200.md
@@ -51,7 +51,7 @@ https://video-rec.herokuapp.com
 
 ## Endpoints
 
-Your website should have the following four endpoints.
+Your website should have the following four standard REST endpoints to create, list, view and delete videos. The backend will also need a way to modify the rating of the video as well.
 
 ### `GET` "/"
 
@@ -132,3 +132,9 @@ if not successful:
   "message": "Video could not be deleted"
 }
 ```
+
+### Updating the rating
+
+Your backend also needs to have a way to allow the rating of a video to be modified.
+
+Design this feature yourself based on what you have learned in the Syllabus. 


### PR DESCRIPTION
When assessing the Final Project we have seen that in a lot of solutions the rating buttons that were added during lvl 100 are not using the backend at all, and are only done on the frontend side.

After checking with the trainees this was likely because the backend requirements at the level 200 page did not ask for this to be implemented, and a lot of trainees when checking the lvl 300 requirements they were only updating the backend to use a database for the features required here, and did not add the extra bit required for ratings to work.

This Pull Request makes it explicit that the trainees will need to include a way to handle rating changes when implementing the backend at lvl 200. It tries however not to be explicit on how to design this endpoint (for example it doesn't ask them to use `PATCH /:id` or similar) to allow the trainees to come up with their own ideas how they wish to implement this