### PR TITLE
add create and insert to setup script

### DIFF
--- a/db/initdb.sql
+++ b/db/initdb.sql
@@ -1,0 +1,11 @@
+\c videorec;
+
+DROP TABLE IF EXISTS videos CASCADE;
+
+CREATE TABLE videos (
+    title VARCHAR,
+    src VARCHAR
+);
+
+INSERT INTO videos (title,src) VALUES ('Never Gonna Give You Up','https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+-- you can insert more rows using example data from the example_data.csv file


### PR DESCRIPTION
`CREATE` and `INSERT` are not covered in the first few week of the databases module. Adding these commands into the setup SQL script for use in week 1.


Fixes https://github.com/CodeYourFuture/curriculum/issues/684