### PR TITLE
Improve test diagnostics

### DIFF
--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -1,8 +1,4 @@
-import {
-	render,
-	screen,
-	waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 
@@ -58,13 +54,19 @@ describe("Main Page", () => {
 		);
 
 		// we find the delete button on the website
-		const deleteButton = screen.getAllByText("Remove video")[0];
+		const deleteButton = screen.getAllByRole("button", {
+			name: "Remove video",
+		})[0];
 
 		// then we click it
 		await user.click(deleteButton);
 
 		// wait for the video to get deleted from the page
-		await waitForElementToBeRemoved(deleteButton);
+		await waitFor(() =>
+			expect(
+				screen.getAllByRole("button", { name: "Remove video" })
+			).toHaveLength(1)
+		);
 
 		// we calculate the number of videos after the call
 		const videoContainers = screen.getAllByText(

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -50,7 +50,10 @@ describe("Main Page", () => {
 	it("Removes the video when asked to do", async () => {
 		// we create another fake backend that listens on the delete call, and returns success
 		server.use(
-			http.delete("/api/videos/1", () => HttpResponse.json({ success: true }))
+			http.delete(
+				"/api/videos/1",
+				() => new HttpResponse(null, { status: 204 })
+			)
 		);
 
 		// we find the delete button on the website

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -1,9 +1,9 @@
 import {
 	render,
 	screen,
-	fireEvent,
 	waitForElementToBeRemoved,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 
 import { server } from "./tests/setupTests.js";
@@ -11,6 +11,9 @@ import { server } from "./tests/setupTests.js";
 import App from "./App.jsx";
 
 describe("Main Page", () => {
+	/** @type {import("@testing-library/user-event").UserEvent} */
+	let user;
+
 	beforeEach(async () => {
 		// Here we create a fake backend that will always return two videos when calling the /api/videos endpoint
 		server.use(
@@ -35,6 +38,7 @@ describe("Main Page", () => {
 
 		// Let's wait for one of the videos to appear
 		await screen.findByText("Never Gonna Give You Up");
+		user = userEvent.setup();
 	});
 
 	it("Renders the videos", async () => {
@@ -57,7 +61,7 @@ describe("Main Page", () => {
 		const deleteButton = screen.getAllByText("Remove video")[0];
 
 		// then we click it
-		fireEvent.click(deleteButton);
+		await user.click(deleteButton);
 
 		// wait for the video to get deleted from the page
 		await waitForElementToBeRemoved(deleteButton);
@@ -87,15 +91,11 @@ describe("Main Page", () => {
 		);
 
 		// we fill in the form
-		fireEvent.change(screen.getByRole("textbox", { name: "Title:" }), {
-			target: { value: title },
-		});
-		fireEvent.change(screen.getByRole("textbox", { name: "Url:" }), {
-			target: { value: url },
-		});
+		await user.type(screen.getByRole("textbox", { name: "Title:" }), title);
+		await user.type(screen.getByRole("textbox", { name: "Url:" }), url);
 
 		// then click submit
-		fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+		await user.click(screen.getByRole("button", { name: "Submit" }));
 
 		// wait for the new video to appear
 		await screen.findByText(title);

--- a/db/initdb.sql
+++ b/db/initdb.sql
@@ -1,5 +1,3 @@
-\c videorec;
-
 DROP TABLE IF EXISTS videos CASCADE;
 
 CREATE TABLE videos (

--- a/server/api.test.js
+++ b/server/api.test.js
@@ -21,7 +21,7 @@ describe("/api", () => {
 				it("Returns a successful response if the id exists", async () => {
 					const response = await request(app).delete("/api/videos/1");
 
-					expect(response.statusCode).toBe(200);
+					expect(response.statusCode).toBe(204);
 				});
 
 				it("Deletes the video from the database if the id exists", async () => {

--- a/server/api.test.js
+++ b/server/api.test.js
@@ -9,10 +9,12 @@ describe("/api", () => {
 				const response = await request(app).get("/api/videos");
 
 				expect(response.statusCode).toBe(200);
-				expect(response.body).toEqual([{
-					title: "Never Gonna Give You Up",
-					url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-				}]);
+				expect(response.body).toEqual([
+					{
+						title: "Never Gonna Give You Up",
+						url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+					},
+				]);
 			});
 		});
 

--- a/server/api.test.js
+++ b/server/api.test.js
@@ -9,10 +9,10 @@ describe("/api", () => {
 				const response = await request(app).get("/api/videos");
 
 				expect(response.statusCode).toBe(200);
-				expect(response.body[0].title).toBe("Never Gonna Give You Up");
-				expect(response.body[0].url).toBe(
-					"https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-				);
+				expect(response.body).toEqual([{
+					title: "Never Gonna Give You Up",
+					url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+				}]);
 			});
 		});
 
@@ -31,7 +31,7 @@ describe("/api", () => {
 						"SELECT * FROM videos WHERE id = $1",
 						[1]
 					);
-					expect(dbResponse.rows.length).toBe(0);
+					expect(dbResponse.rows).toHaveLength(0);
 				});
 			});
 		});


### PR DESCRIPTION
The failing states of the tests weren't particularly useful, so:

- `expect(foo.length).toBe(bar)` -> `expect(foo).toHaveLength(bar)`, because the latter shows you what _was_ in `foo` if its length isn't `bar` - see e.g. [`jest/prefer-to-have-length`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-have-length.md)
- `expect(foo[0].bar).toBe(baz)` -> `expect(foo).toEqual([{ bar: baz }])` again because then the failing test tells you what `foo` _was_, rather than _"expected `baz` received `undefined`"_ (or crashing with `TypeError: Cannot read properties of undefined`)
    - Another alternative, which may be useful in some circumstances, would be `expect(foo).toHaveProperty([0, "bar"], baz)`

[![][1]][1]

_From Growing Object-Oriented Software by Nat Pryce and Steve Freeman, © 2010 Nat Pryce, released under [CC BY-SA 4.0][2]._

Also:

- `\c videorec;` broke the test seeding
- Depending on the implementation, `await waitForElementToBeRemoved(deleteButton);` can fail because the same button is reused by React - wait for there to be only one button instead
- Use role-based selectors to give a11y feedback
- Use user-event interactions to let the tests focus on behaviour
- An idiomatic delete is 204 No Content, as the resource no longer exists to return

  [1]: http://www.growing-object-oriented-software.com/figures/feedback-on-diagnostics.svg
  [2]: https://creativecommons.org/licenses/by-sa/4.0/